### PR TITLE
Fix updateNode: don't increment level if no level column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Also, this project likes fast realizes with even one change to get it live short
 
 ## Next release
 New features and bug fixes will be here.
+- Fix `updateNode()`: don't increment level if no level column.
 
 ## 1.6.1 - 2021-07-07
 - Fix `getAncestors()` for `depth` greater than 1.

--- a/index.js
+++ b/index.js
@@ -1077,7 +1077,7 @@ module.exports = function (sequelize, DataTypes, modelName, attributes = {}, opt
                 [Op.lt]: right,
             };
             incOptions.where.rootId = rootId;
-            await Model.increment('level', incOptions);
+            nsOptions.levelColumnName && await Model.increment('level', incOptions);
 
             await this.shiftRlRange(left, right, destLeft - left, rootId, options);
 


### PR DESCRIPTION
Methods using updateNode():
- moveAsLastChildOf
- moveAsFirstChildOf
- moveAsNextSiblingOf
- moveAsPrevSiblingOf